### PR TITLE
Ollama as Claude Code backend provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Interactive chat panel for [Claude Code](https://github.com/anthropics/claude-co
 - **Context extender**: Attach selections, files, or images to prompts.
 - **Permission modes**: Switch between permission levels.
 - **MCP integration**: Auto-connects with [pulsar-mcp](https://github.com/asiloisad/pulsar-mcp).
+- **Ollama integration**: Allows the use of Ollama as AI Backend in Claude Code.
 
 ## Installation
 
@@ -21,6 +22,10 @@ To install `claude-chat` search for [claude-chat](https://web.pulsar-edit.dev/pa
 ## Chat history
 
 Chat sessions are stored in `~/.pulsar/claude-chat-sessions/` directory. Each session is saved as a JSON file containing messages, timestamps, project paths, and token usage.
+
+## Ollama Backend
+
+You can configure a Ollama instance as a Backend by providing the Address like `http://localhost:11434` for local deployments. Additionally you'll have to set a custom model name like `qwen3-coder`.
 
 ## Service
 

--- a/lib/claude-connection.js
+++ b/lib/claude-connection.js
@@ -109,6 +109,8 @@ export default class ClaudeConnection {
 
     const model = Config.model();
     const permissionMode = this.permissionMode || Config.permissionMode();
+    const ollamaAddress = Config.ollamaAddress();
+    const customModel = Config.customModel();
 
     const args = [
       "--output-format", "stream-json",
@@ -121,6 +123,8 @@ export default class ClaudeConnection {
     const mainModule = atom.packages.getActivePackage("claude-chat")?.mainModule;
     const mcpPort = mainModule?.getMcpBridgePort();
     const serverPath = mainModule?.getMcpServerPath();
+
+    const launchVariables = process.env;
 
     if (mcpPort && serverPath) {
       const mcpConfig = {
@@ -138,7 +142,9 @@ export default class ClaudeConnection {
       args.push("--mcp-config", JSON.stringify(mcpConfig));
     }
 
-    if (model && model !== "default") {
+    if (customModel && model && model == "custom") {
+      args.push("--model", customModel);
+    } else if (model && model !== "default") {
       args.push("--model", model);
     }
 
@@ -159,6 +165,16 @@ export default class ClaudeConnection {
       args.push("--resume", this.sessionId);
     }
 
+    // Set Environment Variables for Claude Code to use ollama an AI provider
+    if (ollamaAddress && ollamaAddress !== "") {
+      const launchVariables = {
+        ...process.env,
+        ANTHROPIC_AUTH_TOKEN: 'ollama',
+        ANTHROPIC_BASE_URL: ollamaAddress,
+        ANTHROPIC_API_KEY: '',
+      };
+    }
+
     const claudePath = Config.claudePath();
 
     log.debug("Spawn args", args);
@@ -166,7 +182,7 @@ export default class ClaudeConnection {
     try {
       this.process = spawn(claudePath, args, {
         cwd,
-        env: process.env,
+        env: launchVariables,
         stdio: ["pipe", "pipe", "pipe"],
       });
 

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -44,6 +44,8 @@ export const Config = {
   // Claude CLI settings
   claudePath: () => get("claudePath", "claude"),
   model: () => get("model", "default"),
+  ollamaAddress: () => get("ollamaAddress", "default"),
+  customModel: () => get("customModel", "default"),
 
   // Permission mode
   permissionMode: () => get("permissionMode", "default"),

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
         "default",
         "sonnet",
         "opus",
-        "haiku"
+        "haiku",
+        "custom"
       ],
       "order": 2
     },
@@ -106,6 +107,20 @@
         }
       ],
       "order": 3
+    },
+    "ollamaAddress": {
+      "title": "Ollama Address",
+      "description": "For custom models in Claude Code provided by a Ollama Instance",
+      "type": "string",
+      "default": "",
+      "order": 4
+    },
+    "customModel": {
+      "title": "Custom Model",
+      "description": "Use a custom model name",
+      "type": "string",
+      "default": "",
+      "order": 5
     },
     "debugMode": {
       "title": "Debug Mode",


### PR DESCRIPTION
I added a quick integration for Ollama as a Claude Code backend for locally running LLMs.
This is based on the following Guide:
https://docs.ollama.com/integrations/claude-code
Adding configuration possibilities for the address to a ollama instance in the network and for custom model names.

