### PR TITLE
fix: follow theme panel background color

### DIFF
--- a/styles/panel.less
+++ b/styles/panel.less
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: @tool-panel-background-color;
+  background: transparent;
 }
 
 // Messages container
@@ -13,6 +13,6 @@
   overflow-x: hidden;
   overflow-y: auto;
   padding: @component-padding;
-  background: @pane-item-background-color;
+  background: transparent;
   font-size: var(--editor-font-size);
 }


### PR DESCRIPTION
Thanks for the great Pulsar package! One small thing I noticed is that the panel background color is not working in dark mode, see screenshot, so I made this small fix for this. With this fix, the panel background always has the correct theme color.

<img width="1269" height="900" alt="image" src="https://github.com/user-attachments/assets/d425cccf-a5fb-40a2-9617-de8868cf2bca" />
